### PR TITLE
local.config:mac os x 10.11.1 make fails when TARGET_OS is lowercase

### DIFF
--- a/local.config.darwin
+++ b/local.config.darwin
@@ -1,7 +1,7 @@
 #
 # What system are you building on?   linux or darwin
 #
-export TARGET_OS = darwin
+export TARGET_OS = $(shell uname)
 
 #
 # This defines how many processors you have available to build with


### PR DESCRIPTION
file updated:
local.config.darwin

example failure:
(venv34) vedwin@Vijays-MBP [~/src/vedwin/github/externals-clasp]: make
makefile:17: **\* Invalid TARGET_OS: darwin.  Stop.
